### PR TITLE
Added haxelib.json to the repo such that "haxelib git" works.

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -1,0 +1,13 @@
+{
+  "name": "hxtemplo",
+  "url": "https://github.com/Simn/hxtemplo",
+  "license": "MIT",
+  "description": "Port of the templo engine to haxe.",
+  "version": "3.0.0",
+  "releasenote": "Update to Haxe 3.1.0",
+  "contributors": ["Simn"],
+  "classPath": "src",
+  "dependencies": {
+	  "hxparse": ""
+  }
+}


### PR DESCRIPTION
I took the haxelib.json file from the release archive at lib.haxe.org.
Note that I added one line `"classPath": "src"`.
