### PR TITLE
Truly htmlEscape()

### DIFF
--- a/src/templo/Template.hx
+++ b/src/templo/Template.hx
@@ -188,7 +188,7 @@ class Template {
 	}
 
 	function display(v:Dynamic) {
-		return StringTools.htmlEscape(Std.string(v));
+		return StringTools.htmlEscape(Std.string(v), true);
 	}
 
 	function getIterator(v:Dynamic):Iterator<Dynamic> {


### PR DESCRIPTION
This fixes escaping of quotes in dox. Before:

![](http://i.imgur.com/ZghlXSS.png)

After:

![](http://i.imgur.com/OMipx89.png)

